### PR TITLE
Fix reverse horizontal and reverse vertical word placers

### DIFF
--- a/src/main/java/com/brendan/wordfinder/placer/ReverseHorizontalWordPlacer.java
+++ b/src/main/java/com/brendan/wordfinder/placer/ReverseHorizontalWordPlacer.java
@@ -17,7 +17,7 @@ public class ReverseHorizontalWordPlacer implements WordPlacer {
 
         // Check to see if the grid has enough column for the word starting at the
         // supplied column.
-        if (column - theWord.length() < 0) {
+        if ((column + 1) - theWord.length() < 0) {
             return new WordPlacerResult(false);
         }
 

--- a/src/main/java/com/brendan/wordfinder/placer/ReverseVeriticalWordPlacer.java
+++ b/src/main/java/com/brendan/wordfinder/placer/ReverseVeriticalWordPlacer.java
@@ -17,7 +17,7 @@ public class ReverseVeriticalWordPlacer implements WordPlacer {
 
         // Check to see if the grid has enough column for the word starting at the
         // supplied column.
-        if (row - theWord.length() < 0) {
+        if ((row + 1) - theWord.length() < 0) {
             return new WordPlacerResult(false);
         }
 


### PR DESCRIPTION
Reverse horizontal and reverse vertical word placers were not working when the word length is the same as the number of rows or columns.